### PR TITLE
use ubi8.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-init
+FROM registry.access.redhat.com/ubi8/ubi:8.1
 MAINTAINER ManageIQ https://github.com/ManageIQ/container-httpd
 
 ARG DBUS_API_REF=master


### PR DESCRIPTION

ubi-init
```
Error: 
 Problem: conflicting requests
  - nothing provides system-release = 8.1 needed by centos-repos-8.1-1.1911.0.8.el8.x86_64
(try to add '--skip-broken' to skip uninstallable packages or '--nobest' to use not only best candidate packages)
Removing intermediate container 83ad220ac21d
error: build error: The command '/bin/sh -c dnf -y --disableplugin=subscription-manager install http://mirror.centos.org/centos/8/BaseOS/x86_64/os/Packages/centos-repos-8.1-1.1911.0.8.el8.x86_64.rpm  http://mirror.centos.org/centos/8/BaseOS/x86_64/os/Packages/centos-gpg-keys-8.1-1.1911.0.8.el8.noarch.rpm  &&     dnf -y --disableplugin=subscription-manager module enable mod_auth_openidc &&     dnf -y --disableplugin=subscription-manager install --setopt=tsflags=nodocs     httpd     mod_ssl     sssd     sssd-dbus     mod_auth_gssapi     mod_authnz_pam     mod_intercept_form_submit     mod_lookup_identity     mod_auth_mellon     mod_auth_openidc     c-ares     certmonger     ipa-client     ipa-admintools     adcli     realmd     oddjob     oddjob-mkhomedir     samba-common     samba-common-tools &&     dnf --disableplugin=subscription-manager clean all' returned a non-zero code: 1
```

With ubi8.1 build passed