### PR TITLE
use ubi-init:8.1-45

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-init
+FROM registry.access.redhat.com/ubi8/ubi-init:8.1-45
 MAINTAINER ManageIQ https://github.com/ManageIQ/container-httpd
 
 ARG DBUS_API_REF=master


### PR DESCRIPTION
Cause ubi8-init latest based on ubi8.2
```
FROM ubi8:8.2-ondeck
LABEL maintainer="Red Hat, Inc."
LABEL com.redhat.component="ubi8-init-container"
LABEL com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI"
LABEL name="ubi8/ubi8-init"
LABEL version="8.1"
```