### PR TITLE
Exclude 'test' group when running bundle for dbus_api_service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,7 @@ RUN mkdir -p ${HTTPD_DBUS_API_SERVICE_DIRECTORY}
 RUN cd ${HTTPD_DBUS_API_SERVICE_DIRECTORY} && \
     curl -L https://github.com/ManageIQ/dbus_api_service/tarball/${DBUS_API_REF} | tar vxz -C ${HTTPD_DBUS_API_SERVICE_DIRECTORY} --strip 1 && \
     gem install bundler && \
+    bundle config set without test && \
     bundle install
 COPY container-assets/dbus-api.service /usr/lib/systemd/system/dbus-api.service
 


### PR DESCRIPTION
The httpd-init container build fails due to dbus_api_service bundle error:

```
An error occurred while installing jaro_winkler (1.5.4), and Bundler cannot
continue.
Make sure that `gem install jaro_winkler -v '1.5.4' --source
'https://rubygems.org/'` succeeds before bundling.

In Gemfile:
  manageiq-style was resolved to 1.1.0, which depends on
    rubocop-performance was resolved to 1.7.1, which depends on
      rubocop was resolved to 0.82.0, which depends on
        jaro_winkler
```

manageiq-style was added in https://github.com/ManageIQ/dbus_api_service/pull/19, but that's in 'test' group and the group should have been excluded from httpd-init build anyway.