### PR TITLE
Pull httpd and mod_ssl from UBI, not CentOS Appstream

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ LABEL name="auth-httpd" \
 RUN dnf -y --disableplugin=subscription-manager --setopt=tsflags=nodocs install \
       http://mirror.centos.org/centos/8-stream/BaseOS/${ARCH}/os/Packages/centos-stream-repos-8-2.el8.noarch.rpm \
       http://mirror.centos.org/centos/8-stream/BaseOS/${ARCH}/os/Packages/centos-gpg-keys-8-2.el8.noarch.rpm && \
+    dnf config-manager --setopt=appstream*.exclude=*httpd*,mod_ssl --save && \
     dnf -y --disableplugin=subscription-manager module enable mod_auth_openidc && \
     dnf -y --disableplugin=subscription-manager --setopt=tsflags=nodocs install \
       httpd \


### PR DESCRIPTION
Copy of https://github.com/ManageIQ/container-httpd/pull/74